### PR TITLE
vtt indexing related updates

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -64,6 +64,13 @@ function islandora_oralhistories_admin(array $form, array &$form_state) {
     '#default_value' => variable_get('islandora_oralhistories_annotation_vtt_default_language', 'en'),
   );  
 
+  $form['islandora_oralhistories_annotation_vtt_index_ds_generation'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Generate datastream for WebVTT indexing'),
+    '#description' => t('By default, a datastream for solr indexing will be created when vtt is ingested.'),
+    '#default_value' => variable_get('islandora_oralhistories_annotation_vtt_index_ds_generation', TRUE),
+  );
+  
   $form['actions'] = array('#type' => 'actions');
   $form['actions']['reset'] = array(
     '#type' => 'submit',

--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -71,6 +71,51 @@ function islandora_oralhistories_create_vtt(AbstractObject $object, $force = TRU
 }
 
 /**
+ * This function will create an xml derivative datastream
+ *
+ * @param AbstractObject $object
+ *   An AbstractObject representing an object within Fedora.
+ * @param bool $force
+ *   Whether derivative generation is being forced or not.
+ *
+ * @return array
+ *   An array describing the outcome of the MP4 creation.
+ *
+ * @see hook_islandora_derivative()
+ */
+function islandora_oralhistories_create_vtt_indexing_datastream(AbstractObject $object, $force = TRUE, $hook) {
+  module_load_include('inc', 'islandora_oralhistories', 'includes/utilities');
+  try
+  {
+    $destination_dsid = $hook['destination_dsid'];
+    $source_dsid = $hook['source_dsid'];
+
+    $filename = $destination_dsid . '.xml';
+    $dest = file_build_uri($filename);
+    $content = $object[$source_dsid]->content;
+
+    $cues = parse_vtt($content);
+    $xml = new SimpleXMLElement('<?xml version="1.0" encoding="utf-8"?><cues></cues>');
+
+    foreach ($cues as $cue) {
+      $newCue = $xml->addChild('cue');
+      $newCue->addChild('start', (float)$cue['start_time']);
+      $newCue->addChild('end', (float)$cue['end_time']);    
+      $newCue->addChild('speaker', $cue['name']);
+      $newCue->addChild('vtt_text', $cue['text']);
+    }
+
+    $contentXML = $xml->asXML();
+    $file = file_save_data($contentXML, $dest, FILE_EXISTS_REPLACE);  
+    islandora_oralhistories_add_datastream($object, $destination_dsid, $file->uri);  
+    file_delete($file);
+  }
+  catch (exception $e) {
+    watchdog('Islandora Oralhistories', 'Unable to create vtt indexing datastream: ' . $e->getmessage());    
+  }  
+}
+
+/**
  * Adds the given file as a datastream to the given object.
  *
  * @param AbstractObject $object

--- a/islandora_oralhistories.module
+++ b/islandora_oralhistories.module
@@ -336,7 +336,7 @@ function islandora_oralhistories_islandora_oralhistoriesCModel_islandora_ingest_
 /**
  * Implements hook_islandora_CMODEL_PID_derivative().
  */
-function islandora_oralhistories_islandora_oralhistoriesCModel_islandora_derivative() {
+function islandora_oralhistories_islandora_oralhistoriesCModel_islandora_derivative(AbstractObject $object, $ds_modified_params = array()) {
   $derivatives = array();
 
   if (variable_get('islandora_oralhistories_media_uploaded_type') == 'video') {
@@ -367,6 +367,33 @@ function islandora_oralhistories_islandora_oralhistoriesCModel_islandora_derivat
       'file' => drupal_get_path('module', 'islandora_oralhistories') . '/includes/derivatives.inc',
     );
   }
+
+  // create a derivative if a text/vtt file is ingested and the config is true  
+  if (variable_get('islandora_oralhistories_annotation_vtt_index_ds_generation', TRUE)) {
+    // we don't know the datastream id, thus need to filter if from the object keys
+    $arrVTTDataStreams = array();
+    foreach( $object as $key => $value ){
+      if ($object[$key]->mimetype == "text/vtt"){
+        array_push($arrVTTDataStreams, $key);
+      }
+    }
+
+    // loop through all MEDIATRACK or TRANSCRIPT text/vtt datastreams to see if derivative needs to be created
+    foreach( $arrVTTDataStreams as $key => $value ){
+      $sourceID = $value;
+      $targetID = "INDEX" . $value;
+  
+      $derivatives[] = array(
+        'source_dsid' => $sourceID, 
+        'destination_dsid' => $targetID,
+        'function' => array(
+          'islandora_oralhistories_create_vtt_indexing_datastream',
+        ),
+        'file' => drupal_get_path('module', 'islandora_oralhistories') . '/includes/derivatives.inc',
+      );
+    }
+  }  
+
   return $derivatives;
 }
 

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -119,7 +119,7 @@ function islandora_oralhistories_preprocess_islandora_oralhistories(array &$vari
   foreach ($object as $datastream) {
 
     $getTrack = FALSE;
-    if (preg_match('/TRANSCRIPT/', $datastream->id)) {
+    if (preg_match('/^TRANSCRIPT/', $datastream->id)) {
       if (strpos($datastream->mimetype,'xml') !== false) {
         $transcript_mimetype = 'xml';
       }
@@ -129,7 +129,7 @@ function islandora_oralhistories_preprocess_islandora_oralhistories(array &$vari
       $getTrack = TRUE;
     }
 
-    if (preg_match('/MEDIATRACK/', $datastream->id)) {
+    if (preg_match('/^MEDIATRACK/', $datastream->id)) {
         $getTrack = TRUE;
     }
 


### PR DESCRIPTION
When vtt is uploaded, an xml datastream is created for solr indexing purposes.  

Detail discussion here: 
https://groups.google.com/forum/#!searchin/islandora/indexing$20text$20datastream%7Csort:relevance/islandora/W4gnRHVnS4I/1ULKHSqRAwAJ

Config details:

**foxmlToSolr.xslt**

<xsl:include href="/var/lib/tomcat7/webapps/fedoragsearch/WEB-INF/classes/fgsconfigFinal/index/FgsIndex/islandora_transforms/vtt_solr.xslt"/>`

To tell not to try to index TRANSCRIPT if mimetype is vtt      

```
    <xsl:when test="@CONTROL_GROUP='M' and @ID='TRANSCRIPT' and foxml:datastreamVersion[last()][@MIMETYPE='text/vtt']">
          </xsl:when>     

```

**Vtt_solr.xslt**
(Currently we are just putting into a single variable.  It is xml, we can parse it as required.)

```

<?xml version="1.0" encoding="UTF-8"?>
<!-- ORALHISTORIES TRANSCRIPT -->
<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:foxml="info:fedora/fedora-system:def/foxml#" xmlns:dcterms="http://purl.org/dc/terms/">

 <xsl:template match="foxml:datastream[contains(@ID, 'INDEXMEDIATRACK') or contains(@ID, 'INDEXTRANSCRIPT')]/foxml:datastreamVersion[last()]" name="index_VTT">

     <xsl:param name="prefix">vtt_</xsl:param>
     <xsl:param name="content"/>    

    <field>
      <xsl:attribute name="name">
        <xsl:value-of select="concat($prefix, 'content')"/>
      </xsl:attribute>
      <xsl:value-of select="$content"/>
  </field>     
 </xsl:template>
</xsl:stylesheet>

```
