### PR TITLE
issue-14, issue-22

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -140,7 +140,6 @@ function islandora_oralhistories_transcripts_ui_transcript($ui) {
   // $query = "$qualifier AND " .
   // 'RELS_EXT_hasModel_uri_mt:"islandora:oralhistoriesCModel"';
   $query = "$qualifier";
-  $query .= "&sort=or_start asc";
 
   if ($options['term'] == '') {
     $params = array(


### PR DESCRIPTION
## What is in this PR?
Two users have reported the "Transcript is being processed for display" issue.  Detail description of the issue can be found in those tickets.

https://github.com/digitalutsc/islandora_solution_pack_oralhistories/issues/14
https://github.com/digitalutsc/islandora_solution_pack_oralhistories/issues/22

In short, solr search fails to return results due to  $query .= "&sort=or_start asc" condition.  This is only a problem with certain Solr installations.  Assuming XML would be ordered, this sorting is not necessary.  And removing this condition resolves the issue.  Though, we have not isolated the exact cause, we are pushing the changes to the master to avoid this issues, as we don't expect any major side effects.  

## How to test this PR?

This is difficult as this issue was only reproducible under certain environments.  Doing sanity tests after this PR should be good enough.  

