### PR TITLE
Modifies default tiers and speaker names.  See issue #30.

### DIFF
--- a/transcripts_ui/transcripts_ui.admin.inc
+++ b/transcripts_ui/transcripts_ui.admin.inc
@@ -10,9 +10,8 @@ function transcripts_ui_admin()
         '#collapsed' => FALSE,
     );
     $default_tiers = array(
-        'ts_content_epo' => 'Esperanto',
-        'ts_content_qya' => 'Quenya',
-        'ts_content_sjn' => 'Sindarin',
+        'or_transcript' => 'Transcript',
+        'or_translation' => 'Translation',
     );
     $form['transcripts_ui_tier_settings']['transcripts_ui_tiers'] = array(
         '#title' => t('Tiers'),
@@ -23,8 +22,8 @@ function transcripts_ui_admin()
         '#required' => TRUE,
     );
     $default_speaker_names = array(
-        '@script' => 'Script',
-        'phonetic' => 'Phonetic',
+        'or_speaker' => 'Speaker',
+        'or_solespeaker' => 'Speaker',
     );
     $form['transcripts_ui_tier_settings']['transcripts_ui_speaker_names'] = array(
         '#title' => t('Speaker names'),


### PR DESCRIPTION
# What does this Pull Request do?
Changes default Transcript UI tiers and speaker names.  See issue #30.

Default Tiers: 
```
ts_content_epo|Esperanto
ts_content_qya|Quenya
ts_content_sjn|Sindarin
```
Changed to:
```
or_transcript|Transcript
or_translation|Translation
```
Default Speaker names;
```
@script|Script
phonetic|Phonetic
```
Changed to:
```
or_speaker|Speaker
or_solespeaker|Speaker
```
# How should this be tested?
* Since Transcript UI currently does not have an .install file, you will need to delete `transcripts_ui_speaker_names` and `transcripts_ui_tiers` from the Drupal7 `variable` database table.
* Go to the admin > Islandora > Solution pack configuration > Oral Histories Solution Pack, then click the Transcript UI tab.  You should see the new default tiers and speaker names.
