### PR TITLE
When enable transcript display setting is not checked, the transcript tabs are not displayed.

### DIFF
--- a/theme/islandora-html5-video-side.tpl.php
+++ b/theme/islandora-html5-video-side.tpl.php
@@ -14,6 +14,7 @@
       </div>
     </div>
   </div>
+  <?php if ($params['enable_transcript_display']): ?>
   <div id="transcript-tabs" class="col-sm-6 col-md-6">
     <ul id="tabs-list">
       <li><a href="#transcript-tab">Transcript</a></li>
@@ -27,4 +28,5 @@
       ?>
     </div>
   </div>
+  <?php endif; ?>
 </div>

--- a/theme/islandora-html5-video-stack.tpl.php
+++ b/theme/islandora-html5-video-stack.tpl.php
@@ -14,6 +14,7 @@
       </div>
     </div>
   </div>
+  <?php if ($params['enable_transcript_display']): ?>
   <div id="transcript-tabs" class="col-sm-12 col-md-12">
     <ul id="tabs-list">
       <li><a href="#transcript-tab">Transcript</a></li>
@@ -27,4 +28,5 @@
       ?>
     </div>
   </div>
+  <?php endif; ?>
 </div>


### PR DESCRIPTION
When enable transcript display setting is not checked, the transcript tabs are not displayed.  See issue #37.

# What does this Pull Request do?
Transcript tabs are not rendered when enable transcript display setting is not checked.

# What's new?
Added conditional in the relevant template files to completely hide transcript tabs when enable transcript display setting is not checked.

# How should this be tested?
* After clearing the cache, check that the transcript tabs are not displayed as per issue #37 when the enable transcript display setting is not checked.
