### PR TITLE
Adds .install file for transcripts_ui submodule. See issue #46.

### DIFF
--- a/transcripts_ui/transcripts_ui.install
+++ b/transcripts_ui/transcripts_ui.install
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @file
+ * Hooks for installing/unintstalling this module.
+ */
+
+/**
+ * Implements hook_install().
+ */
+function transcripts_ui_install() {
+
+   $default_tiers = array(
+          'or_transcript' => 'Transcript',
+          'or_translation' => 'Translation',
+   );
+   variable_set('transcripts_ui_tiers', $default_tiers);
+   $default_speaker_names = array(
+           'or_speaker' => 'Speaker',
+           'or_solespeaker' => 'Speaker',
+   );
+   variable_set('transcripts_ui_speaker_names', $default_speaker_names);
+}
+
+/**
+ * Implements hook_uninstall().
+ */
+function transcripts_ui_uninstall() {
+  $variables = array(
+    'transcripts_ui_tiers',
+    'transcripts_ui_speaker_names'
+  );
+  array_map('variable_del', $variables);
+}
+


### PR DESCRIPTION
# What does this Pull Request do?
Adds .install file for transcripts_ui submodule. See issue #46.

# What's new?
Provides an .install file for the Transcript UI submodule.  On install, default variable values are set and on uninstall, these variables are deleted from Drupal's variable table.

# How should this be tested?
* Disable and uninstall oral histories and then transcripts_ui via the module admin interface.
* Connect to the mysql command-line client in your environment and check that 
``>  select * from variable where name="transcripts_ui_tiers";``
``> select * from variable where name="transcripts_ui_speaker_names";``
Return an empty result set.
* Enable transcripts_ui via the module admin interface.   Rerun the select queries  - a result set of one row should be returned for each.