### PR TITLE
Provides a small workaround for TypeError created when non-WebVTT is parsed.

### DIFF
--- a/lib/videojs/videojs.js
+++ b/lib/videojs/videojs.js
@@ -7508,48 +7508,50 @@ vjs.TextTrack.prototype.parseCues = function(srcContent) {
     var cue, time, text,
         lines = srcContent.split('\n'),
         line = '', id;
+    if(lines[0].indexOf('WEBVTT') >= 0) {
 
-    for (var i=1, j=lines.length; i<j; i++) {
-        // Line 0 should be 'WEBVTT', so skipping i=0
+        for (var i = 1, j = lines.length; i < j; i++) {
+            // Line 0 should be 'WEBVTT', so skipping i=0
 
-        line = vjs.trim(lines[i]); // Trim whitespace and linebreaks
+            line = vjs.trim(lines[i]); // Trim whitespace and linebreaks
 
-        if (line) { // Loop until a line with content
+            if (line) { // Loop until a line with content
 
-            // First line could be an optional cue ID
-            // Check if line has the time separator
-            if (line.indexOf('-->') == -1) {
-                id = line;
-                // Advance to next line for timing.
-                line = vjs.trim(lines[++i]);
-            } else {
-                id = this.cues_.length;
+                // First line could be an optional cue ID
+                // Check if line has the time separator
+                if (line.indexOf('-->') == -1) {
+                    id = line;
+                    // Advance to next line for timing.
+                    line = vjs.trim(lines[++i]);
+                } else {
+                    id = this.cues_.length;
+                }
+
+                // First line - Number
+                cue = {
+                    id: id, // Cue Number
+                    index: this.cues_.length // Position in Array
+                };
+
+                // Timing line
+                time = line.split(/[\t ]+/);
+                cue.startTime = this.parseCueTime(time[0]);
+                cue.endTime = this.parseCueTime(time[2]);
+
+                // Additional lines - Cue Text
+                text = [];
+
+                // Loop until a blank line or end of lines
+                // Assumeing trim('') returns false for blank lines
+                while (lines[++i] && (line = vjs.trim(lines[i]))) {
+                    text.push(line);
+                }
+
+                cue.text = text.join('<br/>');
+
+                // Add this cue
+                this.cues_.push(cue);
             }
-
-            // First line - Number
-            cue = {
-                id: id, // Cue Number
-                index: this.cues_.length // Position in Array
-            };
-
-            // Timing line
-            time = line.split(/[\t ]+/);
-            cue.startTime = this.parseCueTime(time[0]);
-            cue.endTime = this.parseCueTime(time[2]);
-
-            // Additional lines - Cue Text
-            text = [];
-
-            // Loop until a blank line or end of lines
-            // Assumeing trim('') returns false for blank lines
-            while (lines[++i] && (line = vjs.trim(lines[i]))) {
-                text.push(line);
-            }
-
-            cue.text = text.join('<br/>');
-
-            // Add this cue
-            this.cues_.push(cue);
         }
     }
 


### PR DESCRIPTION
# What does this Pull Request do?
Conditionally checks for WebVTT file to avoid TypeError.

# How should this be tested?
1. Open your browser console and run an Oral History object creating using WebVTT transcript file with closed-captioning on.  You should notice a JavaScript TypeError on page-load in the browser console.
2.  Pull the changes in this pull-request.  Reload the page (clearing your caches as appropriate).  The JavaScript TypeError should no longer appear in your browser console.

# Additional Notes:
`srcContent` is assigned as both WebVTT and the Transcript XML in ``vjs.TextTrack.prototype.parseCues = function(srcContent)`` during the page load process.  A better fix would be to isolate where this is happening and not having  `srcContent` ever be assigned to Transcript XML.

# Interested parties
@Natkeeran 
