### PR TITLE
only show captions for MEDIATRACK files

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -119,8 +119,6 @@ function islandora_oralhistories_transcripts_ui_transcript($ui) {
   $options = $ui->options;
   $transcript_type = $options["type"];
 
-  watchdog('Islandora Oralhistories', 'transcript type ' . $transcript_type);
-
   // If VTT process it using compose_vtt_transcript_as_transcripts_ui function.
   if ($transcript_type == "VTT") {
     return compose_vtt_transcript_as_transcripts_ui($ui);

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -111,7 +111,7 @@ function islandora_oralhistories_preprocess_islandora_oralhistories(array &$vari
   $tracks = array();
   $transcript_mimetype = '';
   foreach ($object as $datastream) {
-
+    $isMediatrack = FALSE;
     $get_track = FALSE;
     if (preg_match('/^TRANSCRIPT/', $datastream->id)) {
       if (strpos($datastream->mimetype, 'xml') !== FALSE) {
@@ -125,6 +125,7 @@ function islandora_oralhistories_preprocess_islandora_oralhistories(array &$vari
 
     if (preg_match('/^MEDIATRACK/', $datastream->id)) {
       $get_track = TRUE;
+      $isMediatrack = TRUE;
     }
 
     // Ensure that even if MEDIATRACK is not present, show TRANSCRIPT
@@ -138,14 +139,16 @@ function islandora_oralhistories_preprocess_islandora_oralhistories(array &$vari
       $track['dsid'] = $datastream->id;
       $track['source_url'] = $source_url;
 
-      // Language Code.
-      $lang_code = 'en';
-      $dsid_arr = explode("_", $track['dsid']);
-      if (isset($dsid_arr[1])) {
-        $track['lang_code'] = strtolower($dsid_arr[1]);
-      }
-      else {
-        $track['lang_code'] = $lang_code;
+      if ($isMediatrack) {
+        // Language Code.
+        $lang_code = 'en';
+        $dsid_arr = explode("_", $track['dsid']);
+        if (isset($dsid_arr[1])) {
+          $track['lang_code'] = strtolower($dsid_arr[1]);
+        }
+        else {
+          $track['lang_code'] = $lang_code;
+        }
       }
 
       // Default Language.

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -149,20 +149,21 @@ function islandora_oralhistories_preprocess_islandora_oralhistories(array &$vari
         else {
           $track['lang_code'] = $lang_code;
         }
+
+        // Default Language.
+        $track_defaults_setting_str = "";
+        if (NULL !== variable_get('islandora_oralhistories_vtt_default_language')) {
+          $track_defaults_setting_str = variable_get('islandora_oralhistories_vtt_default_language');
+        }
+        $track_defaults_setting_str = str_replace(' ', '', $track_defaults_setting_str);
+        $track_defaults_setting_str = explode(",", $track_defaults_setting_str);
+
+        $track['default'] = "";
+        if (in_array($track['lang_code'], $track_defaults_setting_str)) {
+          $track['default'] = "default";
+        }
       }
 
-      // Default Language.
-      $track_defaults_setting_str = "";
-      if (NULL !== variable_get('islandora_oralhistories_vtt_default_language')) {
-        $track_defaults_setting_str = variable_get('islandora_oralhistories_vtt_default_language');
-      }
-      $track_defaults_setting_str = str_replace(' ', '', $track_defaults_setting_str);
-      $track_defaults_setting_str = explode(",", $track_defaults_setting_str);
-
-      $track['default'] = "";
-      if (in_array($track['lang_code'], $track_defaults_setting_str)) {
-        $track['default'] = "default";
-      }
 
       if (isset($object[$datastream->id]) && islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $object[$datastream->id])) {
         $tracks[] = $track;

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -139,6 +139,7 @@ function islandora_oralhistories_preprocess_islandora_oralhistories(array &$vari
       $track['dsid'] = $datastream->id;
       $track['source_url'] = $source_url;
 
+
       if ($isMediatrack) {
         // Language Code.
         $lang_code = 'en';
@@ -162,6 +163,9 @@ function islandora_oralhistories_preprocess_islandora_oralhistories(array &$vari
         if (in_array($track['lang_code'], $track_defaults_setting_str)) {
           $track['default'] = "default";
         }
+      } else {
+        $track['lang_code'] = '';
+        $track['default'] = '';
       }
 
 


### PR DESCRIPTION
# What does this Pull Request do?
Addresses this issue: https://github.com/digitalutsc/islandora_solution_pack_oralhistories/issues/44

# How should this be tested?
* Get the PR
* Enable create MEDIATRACK and showing captions
* Ingest an xml transcript
* Should only show one en option for captions

* Ingest multiple MEDIATRACK (MEDIATRACK_fr, MEDIATRACK_it)
* Verify that only one of each language is shown for options in captions
