### PR TITLE
add xslt to index vtts

### DIFF
--- a/xsl/vtt_solr.xslt
+++ b/xsl/vtt_solr.xslt
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ORALHISTORIES TRANSCRIPT -->
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:foxml="info:fedora/fedora-system:def/foxml#" xmlns:dcterms="http://purl.org/dc/terms/">
+  <xsl:template match="foxml:datastream[contains(@ID, 'INDEXMEDIATRACK') or contains(@ID, 'INDEXTRANSCRIPT')]/foxml:datastreamVersion[last()]" name="index_VTT">
+    <xsl:param name="prefix">vtt_</xsl:param>
+    <xsl:param name="content"/>    
+    <field>
+      <xsl:attribute name="name">
+        <xsl:value-of select="concat($prefix, 'content')"/>
+      </xsl:attribute>
+      <xsl:value-of select="$content"/>
+     </field>     
+  </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
# What does this Pull Request do?
Add xslt to index INDEXMEDIATRACK

# What's new?
new xslt file. Instead of using having the user of the module create their own vtt_solr.xslt

# How should this be tested?
Follow the configure solr steps found in https://github.com/digitalutsc/islandora_solution_pack_oralhistories/wiki/Configuration:--Basic-Indexing-of-transcripts-in-Solr

Except for Step 1, do this instead:

 > cd /var/lib/tomcat7/webapps/fedoragsearch/WEB-INF/classes/fgsconfigFinal/index/FgsIndex/islandora_transforms
 > cp  /var/www/drupal/sites/all/modules/islandora_solution_pack_oralhistories/xsl/or_transcript_solr.xslt ./
> cp  /var/www/drupal/sites/all/modules/islandora_solution_pack_oralhistories/xsl/vtt_solr.xslt ./

and

Ignore Step 5

# Additional Notes:

# Interested parties
@Natkeeran @MarcusBarnes 