### PR TITLE
Closed Caption MEDIATRACK file configuration issue

### DIFF
--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -119,6 +119,7 @@ function islandora_oralhistories_preprocess_islandora_oralhistories(array &$vari
       }
       else {
         $transcript_mimetype = 'vtt';
+        $isMediatrack = TRUE;
       }
       $get_track = TRUE;
     }


### PR DESCRIPTION
# What does this Pull Request do?
If the user uploads a MEDIATRACK_fr as TRANSCRIPT, then this issue can be reproduced: 
https://github.com/digitalutsc/islandora_solution_pack_oralhistories/issues/54  

This is possibly a regression issue.  Addressed it via this PR.

# How should this be tested?
* Get this PR
* Case 1 - xml transcript, mediatrack generated
* Case 2 - one mediatrack transcript
* Case 2 - multiple mediatrack transcripts
* Please test is with various configuration options for the OH solution pack
