### PR TITLE
Uls replace file get contents - addresses Issue 65

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -207,6 +207,22 @@ function islandora_oralhistories_transcripts_ui_transcript($ui) {
 }
 
 /**
+ * This will use the islandora functions to return the datastream that is specified by the $url.
+ * 
+ * @param type $url
+ */
+function islandora_oralhistories_get_datastream_from_url($url) {
+  // This is a bit of a hacky way to pull the $pid and $dsid from the $url for the datastream view.
+  @list($junk, $keep) = explode("/islandora/object/", $url);
+  @list($pid, $keep) = explode("/datastream/", $keep);
+  $pid = urldecode($pid);
+  $dsid = str_replace("/view", "", $keep);
+
+  $islandora_object = islandora_object_load($pid);
+  return ((is_object($islandora_object) && (isset($islandora_object[$dsid]))) ? $islandora_object[$dsid]->content : '');
+}
+
+/**
  * We want to display vtt transcript in similar way to xml transcript.
  *
  * @param object $ui
@@ -221,7 +237,8 @@ function compose_vtt_transcript_as_transcripts_ui($ui) {
   $url = $options["url"];
 
   // Get content from VTT file.
-  $content = file_get_contents($url);
+  $content = islandora_oralhistories_get_datastream_from_url($url);
+
   // Parse the VTT for tcues data.
   $cues = parse_vtt($content);
 


### PR DESCRIPTION
# What does this Pull Request do?
This reworks a line of code that used file_get_contents to fetch an object's transcript datastream - so that it calls directly to fedora using the islandora functions rather than rely on an http request of the web server.

# What's new?
The code change should not be noticed, but on systems that have a web firewall that prevent http calls to same server (to protect against bot attacks).  This code change will allow these kind of configurations to actually display the transcript.

# How should this be tested?
Ensure that an oral history object with a transcript can be viewed and played as before.  It may be beyond the scope of this issue to set up an environment where the web server can not make http requests from itself -- and test that with the old code to see that a transcript is not rendered, and test with the updated code to see that it fixes that issue... but that is why we needed this code fix.

# Additional Notes:
If anything, it could make the loading time of an oral history object a tiny bit faster.  This change should not effect anything else and does not require any change to documentation.