### PR TITLE
redirect to oh object after edit

### DIFF
--- a/includes/transcript.edit.form.inc
+++ b/includes/transcript.edit.form.inc
@@ -122,6 +122,9 @@ function islandora_oralhistories_transcript_edit_form_submit(array $form, array 
     try {
       $datastream->setContentFromString($dom->saveXML());
       drupal_set_message(t('datastream %s is updated.', array('%s' => $datastream->id)), 'status', FALSE);
+      $nodePath = current_path();
+      $nodePath = str_replace("/edit_form/TRANSCRIPT", "", $nodePath);
+      $form_state['redirect'] = $nodePath;
     }
     catch (Exception $e) {
       drupal_set_message(t('Error updating datastream %s %t', array('%s' => $datastream->id, '%t' => $e->getMessage())), 'error', FALSE);
@@ -174,6 +177,9 @@ function edit_transcript_modal(AbstractObject $object, AbstractDatastream $datas
       // Create ajax command array, dismiss the modal window.
       $output = array();
       $output[] = ctools_modal_command_dismiss();
+      $nodePath = current_path();
+      $nodePath = str_replace("/edit_form/TRANSCRIPT/ajax", "", $nodePath);
+      $output[] = ctools_ajax_command_redirect($nodePath);
     }
 
 


### PR DESCRIPTION
# What does this Pull Request do?
This addresses issue https://github.com/digitalutsc/islandora_solution_pack_oralhistories/issues/34 partially. It navigates back to the object after editing the datastream (in the inline form and for the ajax form). It redirects to the object with notification saying the datastream is updated. But, the user still has to reload the page to see the changes reflected in the transcript.

My assumption is that this is a timing issue. We get the transcript display from solr. It takes, even in the VM bit of time to index. We can put an arbitrary time delay, but that is not a deterministic solution.

# How should this be tested?
* Go to manage datastreams for an OH object, click to edit the XML transcript datastream
* It will take you to the inline edit form, make some changes, click to save
* Should take you back to the object (You still have to refresh to see the changes reflected, because it takes time to index)
* Repeat the behavior for editing the transcript via the ajax for (i.e by clicking on the edit button in the interface)

