### PR TITLE
ensure to put CDATA for escape characters for INDEXMEDIATRACK

### DIFF
--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -101,8 +101,16 @@ function islandora_oralhistories_create_vtt_indexing_datastream(AbstractObject $
       $newCue = $xml->addChild('cue');
       $newCue->addChild('start', (float)$cue['start_time']);
       $newCue->addChild('end', (float)$cue['end_time']);    
-      $newCue->addChild('speaker', $cue['name']);
-      $newCue->addChild('vtt_text', $cue['text']);
+
+      $child = $newCue->addChild('speaker');
+      $child_node = dom_import_simplexml($child);
+      $child_owner = $child_node->ownerDocument;
+      $child_node->appendChild($child_owner->createCDATASection($cue['name']));
+
+      $child = $newCue->addChild('vtt_text');
+      $child_node = dom_import_simplexml($child);
+      $child_owner = $child_node->ownerDocument;
+      $child_node->appendChild($child_owner->createCDATASection($cue['text']));
     }
 
     $contentXML = $xml->asXML();


### PR DESCRIPTION
# What does this Pull Request do?
This PR ensures that the INDEXMEDIATRACK xml element values are inside CDATA to handle special 
It addresses this issue: https://github.com/digitalutsc/islandora_solution_pack_oralhistories/issues/75

# How should this be tested?
Please test by following the steps here: https://github.com/digitalutsc/islandora_solution_pack_oralhistories/issues/75