### PR TITLE
Hide the transcript viewer if no transcript is available 

### DIFF
--- a/theme/islandora-html5-video-side.tpl.php
+++ b/theme/islandora-html5-video-side.tpl.php
@@ -14,7 +14,7 @@
       </div>
     </div>
   </div>
-  <?php if ($params['enable_transcript_display']): ?>
+  <?php if ($params['enable_transcript_display'] && isset($params['tracks'])): ?>
   <div id="transcript-tabs" class="col-sm-6 col-md-6">
     <ul id="tabs-list">
       <li><a href="#transcript-tab">Transcript</a></li>

--- a/theme/islandora-html5-video-stack.tpl.php
+++ b/theme/islandora-html5-video-stack.tpl.php
@@ -14,7 +14,7 @@
       </div>
     </div>
   </div>
-  <?php if ($params['enable_transcript_display']): ?>
+  <?php if ($params['enable_transcript_display'] && isset($params['tracks'])): ?>
   <div id="transcript-tabs" class="col-sm-12 col-md-12">
     <ul id="tabs-list">
       <li><a href="#transcript-tab">Transcript</a></li>


### PR DESCRIPTION
Hide the transcript viewer if no transcript is available  - addresses issue #73.

# What does this Pull Request do?
Adds some additional logic to hide the transcript viewer in the theme files for the case when there is no transcript associated with an oral history object.

# What's new?
Hides the transcript view region associated with an oral history object when there is no transcript.

# How should this be tested?
Clear your Drupal cache after pulling the code changes:   
1. Create an oral history object with a transcript (XML or WebVTT).  Assuming that the ingest is successful, you should see the transcript tab as usual.
2. Create an oral history object (video or audio) without adding a transcript (XML or WebVTT).  You should not see the transcript viewer area.

# Additional Notes:
For deployments where there is a need to indicate that an object is an oral history object and that a transcript is not currently available, the theme files may need to be adjusted to indicate this rather than hiding the transcript viewer completely.  If this becomes a need, this can be implemented as additional configuration options (rather than having deployments hack the theme files).

# Interested parties
@kimpham54 
