### PR TITLE
For CC, only vtt tracks need to be displayed

### DIFF
--- a/theme/islandora-html5-video-stack.tpl.php
+++ b/theme/islandora-html5-video-stack.tpl.php
@@ -6,8 +6,10 @@
           <source src="<?php print $params['url']; ?>" type="<?php print $params['mime']; ?>"/>
           <?php if (isset($params['tracks']) && $params['enable_transcript_display']): ?>
             <?php foreach ($params['tracks'] as $key => $track): ?>
-              <track id="track<?php print $key; ?>" src="<?php print $track['source_url']; ?>" srclang="<?php print $track['lang_code']; ?>"
-                     kind="captions" label="<?php print $track['lang_code']; ?>" <?php print $track['default']; ?>>
+              <?php if ($track['MEDIATRACK'] == TRUE): ?>
+                  <track id="track<?php print $key; ?>" src="<?php print $track['source_url']; ?>" srclang="<?php print $track['lang_code']; ?>"
+                    kind="captions" label="<?php print $track['lang_code']; ?>" <?php print $track['default']; ?>>
+              <?php endif; ?>
             <?php endforeach; ?>
           <?php endif; ?>
         </video>

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -142,6 +142,7 @@ function islandora_oralhistories_preprocess_islandora_oralhistories(array &$vari
       $track['source_url'] = $source_url;
 
 
+      $track['MEDIATRACK'] = FALSE;
       if ($isMediatrack) {
         $track['MEDIATRACK'] = TRUE;
         // Language Code.

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -111,6 +111,7 @@ function islandora_oralhistories_preprocess_islandora_oralhistories(array &$vari
   $tracks = array();
   $transcript_mimetype = '';
   foreach ($object as $datastream) {
+
     $isMediatrack = FALSE;
     $get_track = FALSE;
     if (preg_match('/^TRANSCRIPT/', $datastream->id)) {
@@ -142,6 +143,7 @@ function islandora_oralhistories_preprocess_islandora_oralhistories(array &$vari
 
 
       if ($isMediatrack) {
+        $track['MEDIATRACK'] = TRUE;
         // Language Code.
         $lang_code = 'en';
         $dsid_arr = explode("_", $track['dsid']);


### PR DESCRIPTION
# What does this Pull Request do?
Addresses this issue: https://github.com/digitalutsc/islandora_solution_pack_oralhistories/issues/69

# What's new?
Ensures that only VTT or MEDIATRACK files get track created in the UI.

# How should this be tested?
Please follow the steps here: https://github.com/digitalutsc/islandora_solution_pack_oralhistories/issues/69
Ensure that a blank option does not get created.
