### PR TITLE
Improve the vtt parser by using https://github.com/mantas-done/subtitles

### DIFF
--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -57,7 +57,9 @@ function islandora_oralhistories_create_vtt(AbstractObject $object, $force = TRU
         $start = time_mm_ss((string)$cue->start);
         $end = time_mm_ss((string)$cue->end);
         $vtt .= $start . ' --> ' . $end . PHP_EOL;
-        $vtt .= $speaker . (string)$cue->transcript . PHP_EOL;
+        // Remove empty lines.  Not supported in VTT.
+        $transcript_text = preg_replace("/(^[\r\n]*|[\r\n]+)[\s\t]*[\r\n]+/", "\n", (string)$cue->transcript);
+        $vtt .= $speaker . $transcript_text . PHP_EOL;
         $vtt .= PHP_EOL;
       }
       $dsid = 'MEDIATRACK';

--- a/includes/lib/VttConverter.php
+++ b/includes/lib/VttConverter.php
@@ -1,0 +1,104 @@
+<?php
+
+/**
+ * Class VttConverter
+ * Adobted from here: https://github.com/mantas-done/subtitles
+ */
+
+class VttConverter  {
+
+  public function fileContentToInternalFormat($file_content)
+  {
+    $internal_format = []; // array - where file content will be stored
+
+    $blocks = explode("\n\n", trim($file_content)); // each block contains: start and end times + text
+
+    foreach ($blocks as $block) {
+      if (trim($block) == 'WEBVTT') {
+        continue;
+      }
+      $lines = explode("\n", $block); // separate all block lines
+      $times = explode(' --> ', $lines[0]);
+      $name = static::getName($lines[1]);
+
+      $internal_format[] = [
+        'start' => static::vttTimeToInternal($times[0]),
+        'end' => static::vttTimeToInternal($times[1]),
+        'name' => $name,
+        'lines' => array_map(static::fixLine(), array_slice($lines, 1)), // get all the remaining lines from block (if multiple lines of text)
+      ];
+    }
+
+    return $internal_format;
+  }
+
+  public function internalFormatToFileContent(array $internal_format)
+  {
+    $file_content = "WEBVTT\n\n";
+
+    foreach ($internal_format as $k => $block) {
+      $start = static::internalTimeToVtt($block['start']);
+      $end = static::internalTimeToVtt($block['end']);
+      $lines = implode("\n", $block['lines']);
+
+      $file_content .= $start . ' --> ' . $end . "\n";
+      $file_content .= $lines . "\n";
+      $file_content .= "\n";
+    }
+
+    $file_content = trim($file_content);
+
+    return $file_content;
+  }
+
+  // ------------------------------ private --------------------------------------------------------------------------
+
+  protected static function vttTimeToInternal($vtt_time)
+  {
+    $parts = explode('.', '00:' . $vtt_time);
+
+    $only_seconds = strtotime("1970-01-01 {$parts[0]} UTC");
+    $milliseconds = (float)('0.' . $parts[1]);
+
+    $time = $only_seconds + $milliseconds;
+
+    return $time;
+  }
+
+  protected static function internalTimeToVtt($internal_time)
+  {
+    $parts = explode('.', $internal_time); // 1.23
+    $whole = $parts[0]; // 1
+    $decimal = isset($parts[1]) ? $parts[1] : 0; // 23
+
+    $srt_time = gmdate("i:s", floor($whole)) . '.' . str_pad($decimal, 3, '0', STR_PAD_RIGHT);
+
+    return $srt_time;
+  }
+
+  protected static function fixLine()
+  {
+    return function($line) {
+      $regex_vtt_name = '/^\s*<v\s+(?<name>.*)>/';
+      preg_match($regex_vtt_name, $line, $matches);
+      if (array_key_exists('name', $matches)) {
+        $line = preg_replace($regex_vtt_name, '', $line);
+      }
+
+      return $line;
+    };
+  }
+
+  protected static function getName($line)
+  {
+    $regex_vtt_name = '/^\s*<v\s+(?<name>.*)>/';
+    preg_match($regex_vtt_name, $line, $matches);
+
+    $name = "";
+    if (array_key_exists('name', $matches)) {
+      $name = $matches['name'];
+    }
+
+    return $name;
+  }
+}

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -5,6 +5,8 @@
  * Utility functions.
  */
 
+require_once(__DIR__ . '/lib/VttConverter.php');
+
 /**
  * Helper function to build transcript content.
  *
@@ -28,41 +30,26 @@ function vtt_transcript_content($url, $trid) {
  * Helper function to parse vtt file.
  */
 function parse_vtt($data = '') {
-  $output = '';
+
+  $oConverter = new VttConverter();
+  $oVttData = $oConverter->fileContentToInternalFormat($data);
+
   $cues = array();
-  $lines = preg_split('/\n\n/', $data);
-  foreach ($lines as $line) {
-    if ($line == 'WEBVTT') {
-      continue;
-    }
-    if (!empty($line)) {
-      $parts = preg_split('/\n/', $line);
-      $time = explode(' --> ', $parts[0]);
-      $start_time = time_seconds($time[0]);
-      $end_time = time_seconds($time[1]);
+  foreach ($oVttData as $key => $vttData) {
+    $start_time = $vttData['start'];
+    $end_time = $vttData['end'];
+    $name = $vttData['name'];
+    $lines = $vttData['lines'];
+    $lines= array_map('trim', $lines);
+    $text = implode(" ", $lines);
 
-      // Redmine#6611
-      $text = $parts[1];
-      $regex_vtt_name = '/^\s*<v\s+(?<name>.*)>/';
-      preg_match($regex_vtt_name, $text, $matches);
-
-      $name = "";
-      if (array_key_exists('name', $matches)) {
-        $name = $matches['name'];
-        $text = preg_replace($regex_vtt_name, '', $text);
-      }
-
-      $text = preg_replace('/</', '&lt;', $text);
-      $text = preg_replace('/>/', '&gt;', $text);
-      $cues[] = array(
-        'start_time' => $start_time,
-        'end_time' => $end_time,
-        'text' => $text,
-        'name' => $name,
-      );
-    }
-  } // end foreach
-
+    $cues[] = array(
+      'start_time' => $start_time,
+      'end_time' => $end_time,
+      'text' => $text,
+      'name' => $name,
+    );
+  }
   return $cues;
 }
 


### PR DESCRIPTION
# What does this Pull Request do?
This PR addresses this issue: https://github.com/digitalutsc/islandora_solution_pack_oralhistories/issues/81
INDEXMEDIATRACK parses the vtt to create the xml to index.  This bug is due to a bug in the parser.  It did not handle multi line VTT's.

# What's new?
We have adopted the https://github.com/mantas-done/subtitles/blob/master/src/code/Converters/VttConverter.php as the vtt parser.  This resolves the multi-line issue and overall improves the parser.

# How should this be tested?
* Get the PR
* Follow the steps here to test: https://github.com/digitalutsc/islandora_solution_pack_oralhistories/issues/81

# Additional Notes:
* The original xml seems to have some empty space that is not a proper whitespace or tab.  Those empty spaces do show up in the index as well as the UI (if vtt transcript is used).

Thanks @kimpham54 for finding this major bug. 
