### PR TITLE
multiple datastream version issues

### DIFF
--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -66,8 +66,9 @@ function islandora_oralhistories_create_vtt(AbstractObject $object, $force = TRU
       $filename = $dsid . '.vtt';
       $dest = file_build_uri($filename);
       $file = file_save_data($vtt, $dest, FILE_EXISTS_REPLACE);
-      islandora_oralhistories_add_datastream($object, $dsid, $file->uri);
+      $result = islandora_oralhistories_add_datastream($object, $dsid, $file->uri);
       file_delete($file);
+      return $result;
     }
   }
 }

--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -117,12 +117,15 @@ function islandora_oralhistories_create_vtt_indexing_datastream(AbstractObject $
 
     $contentXML = $xml->asXML();
     $file = file_save_data($contentXML, $dest, FILE_EXISTS_REPLACE);  
-    islandora_oralhistories_add_datastream($object, $destination_dsid, $file->uri);  
+    $result = islandora_oralhistories_add_datastream($object, $destination_dsid, $file->uri);
     file_delete($file);
+    return $result;
   }
   catch (exception $e) {
-    watchdog('Islandora Oralhistories', 'Unable to create vtt indexing datastream: ' . $e->getmessage());    
-  }  
+    watchdog('Islandora Oralhistories', 'Unable to create vtt indexing datastream: ' . $e->getmessage());
+    $message = $e->getMessage();
+    return $message;
+  }
 }
 
 /**
@@ -150,7 +153,13 @@ function islandora_oralhistories_add_datastream(AbstractObject $object, $datastr
     else {
       $ds = $object[$datastream_id];
     }
-    $ds->mimetype = $mime_detector->getMimetype($file_uri);
+    // Ensure to set mimetype if necessary, otherwise an additional version gets created.
+    // https://groups.google.com/forum/#!searchin/islandora-dev/hook_islandora_derivative_alter%7Csort:relevance/islandora-dev/GOhw6GhF_9Q/WOT5tUeuBwAJ.
+    $ds_mimetype = $mime_detector->getMimetype($file_uri);
+    if ($ds->mimeType != $ds_mimetype) {
+      $ds->mimeType = $ds_mimetype;
+    }
+
     $ds->setContentFromFile(drupal_realpath($file_uri));
     if ($ingest) {
       $object->ingestDatastream($ds);


### PR DESCRIPTION
# What does this Pull Request do?
Resolves this issue: https://github.com/digitalutsc/islandora_solution_pack_oralhistories/issues/85

# What's new?
As per this thread https://groups.google.com/forum/#!searchin/islandora-dev/hook_islandora_derivative_alter%7Csort:relevance/islandora-dev/GOhw6GhF_9Q/WOT5tUeuBwAJ, if a property is set to the datastream, it tends to create a new version.  Added a test to avoid unnecessarily setting the mimetype property, which was causing the multiple versions. 

# How should this be tested?
* Please follow the issue to reproduce the issue
* Get the PR
* Create a new object and edit to ensure that multiple versions are not being created
