### PR TITLE
use transcript xml file name to determine the language code of the de…

### DIFF
--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -18,9 +18,7 @@
  * @see hook_islandora_derivative()
  */
 function islandora_oralhistories_create_vtt(AbstractObject $object, $force = TRUE) {
-
-
-
+  
   module_load_include('inc', 'islandora_oralhistories', 'includes/utilities');
   if ($force || !isset($object['MEDIATRACK'])) {
     if ($object['TRANSCRIPT']->mimetype == 'text/vtt') {
@@ -164,7 +162,7 @@ function islandora_oralhistories_create_vtt_indexing_datastream(AbstractObject $
  *   An array describing the outcome of the datastream addition.
  */
 function islandora_oralhistories_add_datastream(AbstractObject $object, $datastream_id, $file_uri) {
-  watchdog('oh', '1111111111111111111111111111');
+
   try {
     $ingest = !isset($object[$datastream_id]);
     $mime_detector = new MimeDetect();
@@ -182,7 +180,6 @@ function islandora_oralhistories_add_datastream(AbstractObject $object, $datastr
     if ($ds->mimeType != $ds_mimetype) {
       $ds->mimeType = $ds_mimetype;
     }
-
 
     $ds->setContentFromFile(drupal_realpath($file_uri));
     if ($ingest) {

--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -18,6 +18,9 @@
  * @see hook_islandora_derivative()
  */
 function islandora_oralhistories_create_vtt(AbstractObject $object, $force = TRUE) {
+
+
+
   module_load_include('inc', 'islandora_oralhistories', 'includes/utilities');
   if ($force || !isset($object['MEDIATRACK'])) {
     if ($object['TRANSCRIPT']->mimetype == 'text/vtt') {
@@ -34,7 +37,7 @@ function islandora_oralhistories_create_vtt(AbstractObject $object, $force = TRU
         $solespeaker = "<v " . (string)$cues->solespeaker . ">";
       }
 
-      $vtt = "WEBVTT" . PHP_EOL;      
+      $vtt = "WEBVTT" . PHP_EOL;
       // A blank line, which is equivalent to two consecutive newlines.
       $vtt .= PHP_EOL;
       foreach ($cues as $key => $cue) {
@@ -52,7 +55,7 @@ function islandora_oralhistories_create_vtt(AbstractObject $object, $force = TRU
         }
         if($solespeaker != ""){
           $speaker = $solespeaker;
-        }        
+        }
 
         $start = time_mm_ss((string)$cue->start);
         $end = time_mm_ss((string)$cue->end);
@@ -62,7 +65,11 @@ function islandora_oralhistories_create_vtt(AbstractObject $object, $force = TRU
         $vtt .= $speaker . $transcript_text . PHP_EOL;
         $vtt .= PHP_EOL;
       }
-      $dsid = 'MEDIATRACK';
+
+      $transcript_fileName = $object['TRANSCRIPT']->label;
+      $dsid_suffix = get_dsid_suffix($transcript_fileName);
+
+      $dsid = 'MEDIATRACK' . $dsid_suffix;
       $filename = $dsid . '.vtt';
       $dest = file_build_uri($filename);
       $file = file_save_data($vtt, $dest, FILE_EXISTS_REPLACE);
@@ -71,6 +78,23 @@ function islandora_oralhistories_create_vtt(AbstractObject $object, $force = TRU
       return $result;
     }
   }
+}
+
+/**
+ * Gets the language suffix from transcript xml file if there is any.
+ */
+
+function get_dsid_suffix($transcript_fileName) {
+  $pathInfo = pathinfo($transcript_fileName);
+  $transcript_fileName = $pathInfo['filename'];
+
+  $dsid_suffix = "";
+  $dsid_arr = explode("_", $transcript_fileName);
+  if (isset($dsid_arr[1])) {
+    $dsid_suffix = strtolower($dsid_arr[1]);
+    $dsid_suffix = "_" . $dsid_suffix;
+  }
+  return $dsid_suffix;
 }
 
 /**
@@ -103,7 +127,7 @@ function islandora_oralhistories_create_vtt_indexing_datastream(AbstractObject $
     foreach ($cues as $cue) {
       $newCue = $xml->addChild('cue');
       $newCue->addChild('start', (float)$cue['start_time']);
-      $newCue->addChild('end', (float)$cue['end_time']);    
+      $newCue->addChild('end', (float)$cue['end_time']);
 
       $child = $newCue->addChild('speaker');
       $child_node = dom_import_simplexml($child);
@@ -117,15 +141,12 @@ function islandora_oralhistories_create_vtt_indexing_datastream(AbstractObject $
     }
 
     $contentXML = $xml->asXML();
-    $file = file_save_data($contentXML, $dest, FILE_EXISTS_REPLACE);  
-    $result = islandora_oralhistories_add_datastream($object, $destination_dsid, $file->uri);
+    $file = file_save_data($contentXML, $dest, FILE_EXISTS_REPLACE);
+    islandora_oralhistories_add_datastream($object, $destination_dsid, $file->uri);
     file_delete($file);
-    return $result;
   }
   catch (exception $e) {
     watchdog('Islandora Oralhistories', 'Unable to create vtt indexing datastream: ' . $e->getmessage());
-    $message = $e->getMessage();
-    return $message;
   }
 }
 
@@ -143,23 +164,25 @@ function islandora_oralhistories_create_vtt_indexing_datastream(AbstractObject $
  *   An array describing the outcome of the datastream addition.
  */
 function islandora_oralhistories_add_datastream(AbstractObject $object, $datastream_id, $file_uri) {
+  watchdog('oh', '1111111111111111111111111111');
   try {
     $ingest = !isset($object[$datastream_id]);
     $mime_detector = new MimeDetect();
 
     if ($ingest) {
+
       $ds = $object->constructDatastream($datastream_id, "M");
       $ds->label = $datastream_id;
     }
     else {
       $ds = $object[$datastream_id];
     }
-    // Ensure to set mimetype if necessary, otherwise an additional version gets created.
-    // https://groups.google.com/forum/#!searchin/islandora-dev/hook_islandora_derivative_alter%7Csort:relevance/islandora-dev/GOhw6GhF_9Q/WOT5tUeuBwAJ.
     $ds_mimetype = $mime_detector->getMimetype($file_uri);
+
     if ($ds->mimeType != $ds_mimetype) {
       $ds->mimeType = $ds_mimetype;
     }
+
 
     $ds->setContentFromFile(drupal_realpath($file_uri));
     if ($ingest) {


### PR DESCRIPTION
# What does this Pull Request do?
Addresses this issue: https://github.com/digitalutsc/islandora_solution_pack_oralhistories/issues/70

Implements @kimpham54 suggestion to use transcript file name to set the default file name of the webvtt derivative.

# What's new?
* MEDIATRACK will have language suffix appended to indicate the default language.  If  transcript xml does not have any _language, will default to en (English).

# How should this be tested?
* Get PR
* Upload a transcript xml with file name with language such as test_fr.xml 
* Verify that MEDIATRACK derivative takes that language suffix
* Verify that Closed Caption displays that language option and if that language is one of the default values, it shows the CC by default