### PR TITLE
provide a toggle cues button

### DIFF
--- a/includes/transcript.edit.form.inc
+++ b/includes/transcript.edit.form.inc
@@ -27,6 +27,13 @@ function islandora_oralhistories_transcript_edit_form(array $form, array &$form_
   $form = array();
   $form['#tree'] = TRUE;
 
+  // Button to toggle cues.
+  $form['toggle-cues'] = array(
+    '#type' => 'button',
+    '#value' => 'Toggle Cues',
+    '#attributes' => array('onclick' => 'return (false);'),
+  );
+
   if ($xml) {
     if ($xml->solespeaker) {
       $form['solespeaker'] = array(
@@ -82,6 +89,12 @@ function islandora_oralhistories_transcript_edit_form(array $form, array &$form_
     '#type' => 'submit',
     '#value' => t('Submit'),
   );
+
+  // Handles toggle behavior.
+  $form['#attached']['js'] = array(
+    drupal_get_path('module', 'islandora_oralhistories') . '/js/transcript_edit.js',
+  );
+
   return $form;
 }
 

--- a/js/transcript_edit.js
+++ b/js/transcript_edit.js
@@ -49,7 +49,7 @@ var g_Collapse = true;
                 if (g_Collapse == false) {
                     setTimeout(function() {
                         document.body.scrollTop = document.documentElement.scrollTop = originalTopPosition;
-                    }, 45);
+                    }, 275);
                 }
             });
         } // end attach function

--- a/js/transcript_edit.js
+++ b/js/transcript_edit.js
@@ -37,13 +37,12 @@ var g_Collapse = true;
                         if(isVisible === false) {
                             $(this).click();
                         }
-                        // Collapse
+                    // Collapse
                     } else {
                         if(isVisible === true) {
                             $(this).click();
                         }
                     }
-
                 });
 
                 // Reposition the window to the top.

--- a/js/transcript_edit.js
+++ b/js/transcript_edit.js
@@ -1,0 +1,61 @@
+/**
+ * @file
+ * Handles toggle cues behavior.
+ */
+
+var g_Collapse = true;
+
+(function($){
+    Drupal.behaviors.islandoraOralHistories = {
+
+        attach: function (context, settings) {
+            // Position the button.
+            jQuery('#edit-toggle-cues').css({'float':'right'});
+            jQuery('#edit-toggle-cues').after("<br clear='all'/>");
+
+            // Toggle button clicked.
+            jQuery('#edit-toggle-cues').on('click', function(evt) {
+                if (g_Collapse == true) {
+                    g_Collapse = false;
+                } else {
+                    g_Collapse = true;
+                }
+
+                // Get top position, used to reposition after expand.
+                var originalTopPosition = jQuery('#edit-toggle-cues').position().top;
+                var oModalContent = jQuery("#modalContent");
+                if (oModalContent.length > 0) {
+                    originalTopPosition = jQuery('#modalContent').position().top;
+                }
+
+                // Loop through each fieldset element and mimic click.
+                jQuery( ".fieldset-title" ).each(function( index ) {
+                    var isVisible = jQuery(this).closest("fieldset").find("div").is(":visible");
+
+                    // Expand
+                    if (g_Collapse == false) {
+                        if(isVisible === false) {
+                            $(this).click();
+                        }
+                        // Collapse
+                    } else {
+                        if(isVisible === true) {
+                            $(this).click();
+                        }
+                    }
+
+                });
+
+                // Reposition the window to the top.
+                if (g_Collapse == false) {
+                    setTimeout(function() {
+                        document.body.scrollTop = document.documentElement.scrollTop = originalTopPosition;
+                    }, 45);
+                }
+            });
+        } // end attach function
+    };
+
+})(jQuery);
+
+


### PR DESCRIPTION
# What does this Pull Request do?
This PR implements this ticket: https://github.com/digitalutsc/islandora_solution_pack_oralhistories/issues/59

# What's new?
* Toggle Cues button is added to the XML edit form.  It will expand or collapse all cues.  

# How should this be tested?
* Get the PR
* Test toggling in the ajax form (popup) and in the inline form 
* Sanity testing for editing xml transcripts
