### PR TITLE
Fixes typo in array element syntax.  See issue #105.

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -53,7 +53,7 @@ function islandora_oralhistories_admin(array $form, array &$form_state) {
   $form['islandora_oralhistories_vtt_default_language'] = array(
     '#type' => 'textfield',
     '#title' => t('Specify VTT default language code(s)'),
-    '#description' => t('Please specify the exact suffix added to your webVTT files on ingest. For example, if you added MEDIATRACK_IT, you would need to specify "IT" here in order to have this appear as an option for closed captioning. Whatever you specify will be capitalized in the interface. Using ISO 639-1 language codes is recommended. Example: EN, FR, ES').
+    '#description' => t('Please specify the exact suffix added to your webVTT files on ingest. For example, if you added MEDIATRACK_IT, you would need to specify "IT" here in order to have this appear as an option for closed captioning. Whatever you specify will be capitalized in the interface. Using ISO 639-1 language codes is recommended. Example: EN, FR, ES'),
     '#default_value' => variable_get('islandora_oralhistories_vtt_default_language', 'en'),
   );
 


### PR DESCRIPTION
# What does this Pull Request do?
Fixes typo in array element syntax.  See issue #105 and comment https://github.com/Islandora-Labs/islandora_solution_pack_oralhistories/commit/b00e7a21f3623386ae1a533d7beab5f3321e6d07#commitcomment-23315032.
# How should this be tested?
Running `php -l` against `includes/admin.form.inc` in the command line will produce  a parse error before the suggested typo fix and not produce syntax error afterwards.

# Additional Notes:
Thank you Wit Meesangnil (@witt) for spotting the typo and bringing it to our attention.

