### PR TITLE
Issue 107

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
       env: FEDORA_VERSION="3.7.0"
     - php: "5.3.3"
       dist: precise
-    env: FEDORA_VERSION="3.8.1"
+      env: FEDORA_VERSION="3.8.1"
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,23 @@ sudo: true
 language: php
 
 php:
-  - 5.3.3
   - 5.4
   - 5.5
+
+matrix:
+  include:
+    - php: "5.3.3"
+      dist: precise
+      env: FEDORA_VERSION="3.5"
+    - php: "5.3.3"
+      dist: precise
+      env: FEDORA_VERSION="3.6.2"
+    - php: "5.3.3"
+      dist: precise
+      env: FEDORA_VERSION="3.7.0"
+    - php: "5.3.3"
+      dist: precise
+    env: FEDORA_VERSION="3.8.1"
 
 branches:
   only:
@@ -58,5 +72,5 @@ script:
   - phpcpd --names *.module,*.inc,*.test sites/all/modules/islandora_solution_pack_oralhistories
   - drush test-run --uri=http://localhost:8081 "Islandora Oralhistories"
 
-notifications:
-  irc: "irc.freenode.org#islandora"
+#notifications:
+#  irc: "irc.freenode.org#islandora"

--- a/includes/lib/VttConverter.php
+++ b/includes/lib/VttConverter.php
@@ -9,7 +9,7 @@ class VttConverter  {
 
   public function fileContentToInternalFormat($file_content)
   {
-    $internal_format = []; // array - where file content will be stored
+    $internal_format = array(); // array - where file content will be stored
 
     $blocks = explode("\n\n", trim($file_content)); // each block contains: start and end times + text
 
@@ -21,12 +21,12 @@ class VttConverter  {
       $times = explode(' --> ', $lines[0]);
       $name = static::getName($lines[1]);
 
-      $internal_format[] = [
+      $internal_format[] = array(
         'start' => static::vttTimeToInternal($times[0]),
         'end' => static::vttTimeToInternal($times[1]),
         'name' => $name,
         'lines' => array_map(static::fixLine(), array_slice($lines, 1)), // get all the remaining lines from block (if multiple lines of text)
-      ];
+      );
     }
 
     return $internal_format;


### PR DESCRIPTION
# What does this Pull Request do?
Travis-CI build was failing for PHP 5.3.3 because of change to default trusty distribution and use of unsupported array syntax in `VttConverter.php.`  Addresses issue https://github.com/Islandora-Labs/islandora_solution_pack_oralhistories/issues/107.
# What's new?
 * Uses a build matrix in the `.travis.yml` file.  Note that http://lint.travis-ci.org/ reports a problem with the use of dist, but this is a known issue.    
* Comments-out notifications to the Islandora IRC channel in `.travis.yml` as we've been testing the build a lot.
* Uses `array()` syntax in rather than `[]` for array initialization in `VttConverter.php` for backwards compatibility with PHP 5.3.3.

# How should this be tested?
On submitting the pull-request, wait for Travis-ci to complete the build.  The build should be successful.

# Additional Notes:
Thanks to @witt for pointing out the typo noted in issue https://github.com/Islandora-Labs/islandora_solution_pack_oralhistories/issues/105 which brought the Travis-ci build problem to our attention.

# Interested parties
@Natkeeran 
