### PR TITLE
Addresses issue #112.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 #islandora_solution_pack_oralhistories
 
 sudo: true
-
+dist: trusty
 language: php
 
 php:
@@ -56,7 +56,7 @@ before_install:
   - ln -s $HOME/ctools sites/all/modules/ctools
 
   - sudo sh $HOME/islandora_solution_pack_video/tests/scripts/ffmpeg-install.sh
-  
+
   - drush en --user=1 --yes islandora_oralhistories
   - drush en --user=1 --yes islandora_basic_collection
   - drush en --user=1 --yes islandora_video


### PR DESCRIPTION
# What does this Pull Request do?
Addresses issue #112 by explicitly stating the default distribution in `.travis.yml` as `trusty` so that the PHP 5.3.3 test should successfully build using the older `precise` distribution.

# How should this be tested?
* Assuming that the updated`.travis.yml` file provided in this pull-request is used for the build for the pull-request, the Travis CI build should complete successfully.
