### PR TITLE
Addresses issue #94

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -187,6 +187,8 @@ function islandora_oralhistories_transcripts_ui_transcript($ui) {
         }
       }
     }
+  } else {
+    watchdog('Islandora Oralhistories', "Solr query for '$query' in " . __FUNCTION__ . " (file " . __FILE__ . ") returned no results. ", $variables = array(), $severity = WATCHDOG_WARNING, $link = NULL);
   }
 
   $highlights = isset($json['highlighting']) ? $json['highlighting'] : NULL;


### PR DESCRIPTION
# What does this Pull Request do?
Addresses issue #94, by creating a watchdog log message if Solr has not indexed the content, to help when debugging when captions do not show.   Initial work addressing issue #94 was done in https://github.com/Islandora-Labs/islandora_solution_pack_oralhistories/pull/95 by @McFateM.  This pull-request has a cleaner history to merge.

# What's new?
A log message is created when a user tries accessing an Oral History object when Solr has not indexed the transcript content.

# How should this be tested?
Previously tested in @McFateM's [pull-request](https://github.com/Islandora-Labs/islandora_solution_pack_oralhistories/pull/95).  

# Additional Notes:
A note about the log message might be helpful in new wiki page that details suggestions on how to debug the module beyond existing documentation to cover the case covered in issue #94.

Thanks again to @McFateM for reporting issue #94 and the initial approach to addressing it (which has only been slightly changed in this pull request.)

# Interested parties
@McFateM @Natkeeran @kimpham54 
