### PR TITLE
Adjust css so that speaker name does not overlap transcript content. …

### DIFF
--- a/css/islandora_oralhistories.theme.css
+++ b/css/islandora_oralhistories.theme.css
@@ -157,3 +157,19 @@ li.vjs-menu-item {
     font-size: 1em !important;
     text-transform: uppercase !important;
 }
+
+/*
+ Provides em width for tier selector button in the transcript viewer so that
+ "Transcript, Translation, Speaker" text is not wider than the button width.
+ Adjustment of this value may be necessary depending on the given theme.
+*/
+.bootstrap-select:not([class*="col-"]):not([class*="form-control"]):not(.input-group-btn) {
+    width: 15.5em !important;
+}
+/*
+ Provides 1em of padding around the speaker name in the transcript viewer
+ so that it does not overlap with the transcript content.
+*/
+div.speaker-name {
+    padding-right: 1em;
+}


### PR DESCRIPTION
Addresses issue #111.

# What does this Pull Request do?
Two adjustments to the transcript viewer css.

1.  Increases the width of the teir selector button so that if all of "Transcript, Translation, Speaker" are selected, the text in the button is less than the width of the button.
2. Provides right padding to the speaker name div so that the speaker name will not overlap transcript content on the right.

# How should this be tested?
1.  In your test environment, upload some oral history content where the speaker name was overlapping the transcript content.
2.  Pull in the changes and then clear the Drupal cache so that the new CSS rules will be loaded.
3.  When you select Transcript, Translation, Speaker, the text should be contained within the border of the tier select button.   Also, the speaker name should no longer overlap the transcript content.

# Additional Notes:
These new CSS values may need to be adjusted based on a given sites' theme (unconfirmed).

# Interested parties
@kimpham54 
