### PR TITLE
Issue 119

### DIFF
--- a/includes/oralhistories_upload.form.inc
+++ b/includes/oralhistories_upload.form.inc
@@ -118,14 +118,6 @@ function islandora_oralhistories_upload_form_submit(array $form, array &$form_st
     $fid = $form_state['values']['transcript_file'];
     islandora_oralhistories_create_transcript_ds($fid, $object);
   }
-
-  // record uploaded media file type
-  if (preg_match('/video/', $media_file->filemime)) {
-    $media_upload_type = 'video';
-  } else {
-    $media_upload_type = 'audio';
-  }
-  variable_set('islandora_oralhistories_media_uploaded_type', $media_upload_type);
 }
 
 /**

--- a/islandora_oralhistories.install
+++ b/islandora_oralhistories.install
@@ -48,7 +48,7 @@ function islandora_oralhistories_update_7100() {
 /**
  * Implements hook_update_N().
  */
-function islandora_oralhistories_update_7001() {
+function islandora_oralhistories_update_7101() {
   // Delete previously installed variables as needed.
   if (variable_get('islandora_oralhistories_transcript_layout_side') !== NULL) {
     // Delete variable.
@@ -62,6 +62,6 @@ function islandora_oralhistories_update_7001() {
  * It is no longer used as per
  * https://github.com/Islandora-Labs/islandora_solution_pack_oralhistories/issues/119.
  */
-function islandora_oralhistories_update_7101() {
+function islandora_oralhistories_update_7102() {
   variable_del('islandora_oralhistories_media_uploaded_type');
 }

--- a/islandora_oralhistories.install
+++ b/islandora_oralhistories.install
@@ -14,7 +14,6 @@ function islandora_oralhistories_install() {
   module_load_include('inc', 'islandora', 'includes/solution_packs');
   islandora_install_solution_pack('islandora_oralhistories');
   // Set variable for media type uploaded.
-  variable_set('islandora_oralhistories_media_uploaded_type', '');
   variable_set('islandora_oralhistories_make_vtt', FALSE);
   variable_set('islandora_oralhistories_enable_caption_display', FALSE);
   variable_set('islandora_oralhistories_enable_transcript_display', FALSE);
@@ -27,7 +26,6 @@ function islandora_oralhistories_uninstall() {
   module_load_include('inc', 'islandora', 'includes/solution_packs');
   $variables = array(
     'islandora_oralhistories_viewers',
-    'islandora_oralhistories_media_uploaded_type',
     'islandora_oralhistories_enable_caption_display',
     'islandora_oralhistories_make_vtt',
     'islandora_oralhistories_enbable_transcript_display',
@@ -56,4 +54,14 @@ function islandora_oralhistories_update_7001() {
     // Delete variable.
     variable_del('islandora_oralhistories_transcript_layout_side');
   };
+}
+
+/**
+ * Removes the variable `islandora_oralhistories_media_uploaded_type`.
+ *
+ * It is no longer used as per
+ * https://github.com/Islandora-Labs/islandora_solution_pack_oralhistories/issues/119.
+ */
+function islandora_oralhistories_update_7101() {
+  variable_del('islandora_oralhistories_media_uploaded_type');
 }

--- a/islandora_oralhistories.module
+++ b/islandora_oralhistories.module
@@ -276,7 +276,7 @@ function islandora_oralhistories_islandora_oralhistoriesCModel_islandora_derivat
     }
   }
   elseif ($type == 'audio') {
-    if (module_exists('islandora_video') && function_exists('islandora_video_islandora_sp_videoCModel_islandora_derivative')) {
+    if (module_exists('islandora_audio') && function_exists('islandora_audio_islandora_sp_audiocmodel_islandora_derivative')) {
       $derivatives = islandora_audio_islandora_sp_audiocmodel_islandora_derivative();
     }
     else {

--- a/islandora_oralhistories.module
+++ b/islandora_oralhistories.module
@@ -254,7 +254,19 @@ function islandora_oralhistories_islandora_oralhistoriesCModel_islandora_ingest_
 function islandora_oralhistories_islandora_oralhistoriesCModel_islandora_derivative(AbstractObject $object, $ds_modified_params = array()) {
   $derivatives = array();
 
-  if (variable_get('islandora_oralhistories_media_uploaded_type') == 'video') {
+  // Determine type of OBJ.
+  $type = NULL;
+  if (isset($object['OBJ'])) {
+    if (preg_match('/video/', $object['OBJ']->mimetype)) {
+      $type = 'video';
+    }
+    else {
+      $type = 'audio';
+    }
+  }
+
+  // Determine derivatives based on OBJ.
+  if ($type == 'video') {
     if (module_exists('islandora_video') && function_exists('islandora_video_islandora_sp_videoCModel_islandora_derivative')) {
       $derivatives = islandora_video_islandora_sp_videoCModel_islandora_derivative();
     }
@@ -263,8 +275,7 @@ function islandora_oralhistories_islandora_oralhistoriesCModel_islandora_derivat
       drupal_exit();
     }
   }
-
-  if (variable_get('islandora_oralhistories_media_uploaded_type') == 'audio') {
+  elseif ($type == 'audio') {
     if (module_exists('islandora_video') && function_exists('islandora_video_islandora_sp_videoCModel_islandora_derivative')) {
       $derivatives = islandora_audio_islandora_sp_audiocmodel_islandora_derivative();
     }
@@ -273,6 +284,7 @@ function islandora_oralhistories_islandora_oralhistoriesCModel_islandora_derivat
       drupal_exit();
     }
   }
+
   if (variable_get('islandora_oralhistories_make_vtt', TRUE)) {
     $derivatives[] = array(
       'source_dsid' => 'TRANSCRIPT',


### PR DESCRIPTION
This pull is meant to address the issues outlined in [119](https://github.com/Islandora-Labs/islandora_solution_pack_oralhistories/issues/119)

It removes the variable `islandora_oralhistories_media_uploaded_type` and makes derivatives rely on the mimetype of the OBJ DS directly.

# How should this be tested?

This can be tested by ingesting an OH audio file followed by an OH video. Before the fix re-running derivatives on the OH audio would generate video derivatives. After the fix it will generate audio derivatives. There are update hooks in this pull that remove variables. It should be verified that they run and remove the variables.

# Additional Notes:

This change would impact any downstream code relying on the variable being removed.
