### PR TITLE
Added isset check to some params.

### DIFF
--- a/theme/islandora-html5-video-stack.tpl.php
+++ b/theme/islandora-html5-video-stack.tpl.php
@@ -2,8 +2,8 @@
   <div class="col-sm-12 col-md-12">
     <div data-transcripts-role="video" data-transcripts-id="<?php print $params['trid']; ?>">
       <div align="center" id="video_container">
-        <video class="video-js vjs-default-skin embed-responsive-item" controls poster="<?php if(isset($params['tn'])){print$params['tn'];} ?>" preload="auto"  width="100%" height="360" data-setup="{}" id="video-js-oh">
-          <source src="<?php if(isset($params['url'])){print $params['url'];} ?>" type="<?php if(isset($params['mime'])){print$params['mime'];} ?>"/>
+        <video class="video-js vjs-default-skin embed-responsive-item" controls poster="<?php if(isset($params['tn'])){print $params['tn'];} ?>" preload="auto"  width="100%" height="360" data-setup="{}" id="video-js-oh">
+          <source src="<?php if(isset($params['url'])){print $params['url'];} ?>" type="<?php if(isset($params['mime'])){print $params['mime'];} ?>"/>
           <?php if (isset($params['tracks']) && $params['enable_transcript_display']): ?>
             <?php foreach ($params['tracks'] as $key => $track): ?>
               <?php if ($track['MEDIATRACK'] == TRUE): ?>

--- a/theme/islandora-html5-video-stack.tpl.php
+++ b/theme/islandora-html5-video-stack.tpl.php
@@ -2,8 +2,8 @@
   <div class="col-sm-12 col-md-12">
     <div data-transcripts-role="video" data-transcripts-id="<?php print $params['trid']; ?>">
       <div align="center" id="video_container">
-        <video class="video-js vjs-default-skin embed-responsive-item" controls poster="<?php print $params['tn']; ?>" preload="auto"  width="100%" height="360" data-setup="{}" id="video-js-oh">
-          <source src="<?php print $params['url']; ?>" type="<?php print $params['mime']; ?>"/>
+        <video class="video-js vjs-default-skin embed-responsive-item" controls poster="<?php if(isset($params['tn'])){print$params['tn'];} ?>" preload="auto"  width="100%" height="360" data-setup="{}" id="video-js-oh">
+          <source src="<?php if(isset($params['url'])){print $params['url'];} ?>" type="<?php if(isset($params['mime'])){print$params['mime'];} ?>"/>
           <?php if (isset($params['tracks']) && $params['enable_transcript_display']): ?>
             <?php foreach ($params['tracks'] as $key => $track): ?>
               <?php if ($track['MEDIATRACK'] == TRUE): ?>


### PR DESCRIPTION
# What does this Pull Request do?
The template for oral histories would throw errors when a new OH item was ingested due to the asynchronous nature of derivative generation. Certain params had the possibilities of not yet being present when the template is first shown after ingest.

# What's new?
Added an isset check to affected params: 'tn', 'mime', 'url'.

# How should this be tested?
Ingest an oral histories compound. Before change, errors may appear. After change, errors willl not be thrown,

# Interested parties
   @MarcusBarnes


