### PR TITLE
Check if media_dsid is set before using.

### DIFF
--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -91,7 +91,7 @@ function islandora_oralhistories_preprocess_islandora_oralhistories(array &$vari
   }
 
   try {
-    if (isset($object[$media_dsid]) && islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $object[$media_dsid])) {
+    if ($media_dsid && isset($object[$media_dsid]) && islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $object[$media_dsid])) {
       $media_url = url("islandora/object/{$object->id}/datastream/$media_dsid/view", array('absolute' => TRUE));
       $viewer_params += array(
         'mime' => $object[$media_dsid]->mimetype,

--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -59,6 +59,9 @@ function islandora_oralhistories_preprocess_islandora_oralhistories(array &$vari
     'pid' => $object->id,
   );
 
+  // Deferred derivative generation makes it possible that there won't be a
+  // media dsid immediately.
+  $media_dsid = FALSE;
   if (preg_match('/^video/i', $object['OBJ']->mimetype)) {
     $viewer_params += array(
       'media_tag' => 'video',


### PR DESCRIPTION
# What does this Pull Request do?
Another case where a derivative may not be present til later, or derivative generation fails with "Play OBJ datastream if MP4 is not present" being unchecked.

# What's new?
Conditional check.

# How should this be tested?
Ingest an object with deferred derivative generation set and the "Play OBJ datastream if MP4 is not present" unchecked within the configuration for the video SP.
