### PR TITLE
Corrected call to islandora_oralhistories_islandora_oralhistoriesCMod…

### DIFF
--- a/islandora_oralhistories.module
+++ b/islandora_oralhistories.module
@@ -251,7 +251,7 @@ function islandora_oralhistories_islandora_oralhistoriesCModel_islandora_ingest_
 /**
  * Implements hook_islandora_CMODEL_PID_derivative().
  */
-function islandora_oralhistories_islandora_oralhistoriesCModel_islandora_derivative(AbstractObject $object, $ds_modified_params = array()) {
+function islandora_oralhistories_islandora_oralhistoriesCModel_islandora_derivative(AbstractObject $object) {
   $derivatives = array();
 
   // Determine type of OBJ.


### PR DESCRIPTION
Attention @MarcusBarnes  
Addresses issue #109.

The call to implement islandora_oralhistories_islandora_oralhistoriesCModel_islandora_derivative() for hook_islandora_CModel_islandora_derivative had an extra argument that was not used.   When ingesting objects using the Islandora Multi-Importer this extra argument apparently caused the hook function to be skipped because it's argument list did not fit the pattern required for a valid hook_islandora_CModel_islandora_derivative() function.

I simply removed the unused argument and now IMI appears to invoke the function properly.