### PR TITLE
More broad usage for textareas in TRANSCRIPT edit form, updated comment

### DIFF
--- a/includes/transcript.edit.form.inc
+++ b/includes/transcript.edit.form.inc
@@ -18,7 +18,6 @@
  *   The Drupal form definition.
  */
 function islandora_oralhistories_transcript_edit_form(array $form, array &$form_state, AbstractObject $object) {
-
   if (isset($object['TRANSCRIPT'])) {
     $transcript = $object['TRANSCRIPT'];
 
@@ -60,12 +59,15 @@ function islandora_oralhistories_transcript_edit_form(array $form, array &$form_
           );
 
           if (is_object($xml->cue[$i])) {
+            $textfield_node_names = array('solespeaker', 'speaker', 'start', 'end');
+
             foreach ($xml->cue[$i] as $child) {
               $node_name = $child->getName();
-              $is_textarea = FALSE;
+              $is_textarea = TRUE;
 
-              if ($node_name == 'transcript') {
-                $is_textarea = TRUE;
+              // Check to see if cue data should be in textfield.
+              if (in_array($node_name, $textfield_node_names)) {
+                $is_textarea = FALSE;
               }
 
               $form['cues'][$fieldset][$node_name] = array(
@@ -98,6 +100,11 @@ function islandora_oralhistories_transcript_edit_form(array $form, array &$form_
 
 /**
  * Submit handler for islandora_oralhistories_transcript_edit_form.
+ *
+ * @param array $form
+ *   The Drupal form.
+ * @param array $form_state
+ *   The Drupal form state.
  */
 function islandora_oralhistories_transcript_edit_form_submit(array $form, array &$form_state) {
   $object = $form_state['object'];


### PR DESCRIPTION
# What does this Pull Request do?

A relatively small pull request to address proper form elements usage for transcript/translation data. If the XML node is a `solespeaker`,`speaker`,`start` or `end` it should use a textfield, otherwise default to a textarea.

# How should this be tested?

Before pulling down the changes, ingest a test OH object using [this file](https://github.com/digitalutsc/testing/blob/master/OH%20testing%20objects/flyingfarmertranscriptsmultispeakermultitier.xml) as the transcript. When you go to edit the transcript you'll notice that the translation_* transcripts use textfields rather than textareas. This is bad for many reasons, but the biggest issue is the default character limit being 128.

Pull down the changes, and those translations should now be using big, beautiful textareas.

# Interested parties
@MarcusBarnes