### PR TITLE
Fixes last cue not appearing in the edit form.

### DIFF
--- a/includes/transcript.edit.form.inc
+++ b/includes/transcript.edit.form.inc
@@ -49,7 +49,7 @@ function islandora_oralhistories_transcript_edit_form(array $form, array &$form_
         }
 
         // Handle the cue data, expand the first cue.
-        for ($i = 0; $i < ($xml->count() - 1); $i++) {
+        for ($i = 0; $i < ($xml->count()); $i++) {
           $fieldset = 'cue_' . $i;
           $form['cues'][$fieldset] = array(
             '#type' => 'fieldset',


### PR DESCRIPTION
# What does this Pull Request do?
The last cue will now appear in the edit form when editing the transcript XML.

# How should this be tested?
Create a new Oral History object with transcript XML.  The correct number of cues should appear in the edit transcript form.

# Additional Notes:
Those affected by this issue https://github.com/Islandora-Labs/islandora_solution_pack_oralhistories/issues/134 may have to manually fix their transcript XML. 

Thanks to @Natkeeran for catching that the final cue was not appearing after some recent changes.

# Interested parties
@BrandonMorr @Natkeeran 
