### PR TITLE
add classes to array for later use

### DIFF
--- a/transcripts_ui/TranscriptUI.php
+++ b/transcripts_ui/TranscriptUI.php
@@ -73,6 +73,7 @@ class TranscriptUI
                         } else {
                             $tier_list[] = array(
                                 '#theme' => 'transcripts_ui_tcu_tier',
+                                '#classes' => array(),
                                 '#tier_name' => $tier,
                                 '#tier_text' => $sentence->$tier,
                             );
@@ -80,6 +81,7 @@ class TranscriptUI
                     } else {
                         $tier_list[] = array(
                             '#theme' => 'transcripts_ui_tcu_tier',
+                            '#classes' => array(),
                             '#tier_name' => $tier,
                             '#tier_text' => $sentence->$tier,
                         );
@@ -102,6 +104,7 @@ class TranscriptUI
                     ),
                     'speaker_name' => array(
                         '#theme' => 'transcripts_ui_speaker_name',
+                        '#classes' => array(),
                         '#sid' => $sid,
                         '#speaker_name' => $speaker_tiers,
                         '#speaker_turn' => $speaker_tiers == $last_speaker_tiers ? 'same-speaker' : 'new-speaker',


### PR DESCRIPTION
# What does this Pull Request do?
PHP 7+ complains about un-supported type
https://github.com/Islandora-Labs/islandora_solution_pack_oralhistories/blob/7.x/transcripts_ui/theme/transcripts_ui.theme.inc#L51-L52
https://github.com/Islandora-Labs/islandora_solution_pack_oralhistories/blob/7.x/transcripts_ui/theme/transcripts_ui.theme.inc#L66-L67

# What's new?
Set default empty array for later use in theme process.


# How should this be tested?
View a OH object with transcript display enabled with PHP7+. Prior to PR, Drupal will white screen and with PR you can view object.

# Interested parties
@MarcusBarnes 
