### PR TITLE
Add aria-label attribute to tier-selector to fix accessibility error

### DIFF
--- a/transcripts_ui/theme/transcripts_ui.theme.inc
+++ b/transcripts_ui/theme/transcripts_ui.theme.inc
@@ -9,7 +9,7 @@ function theme_transcripts_ui_transcript_controls($vars)
 function theme_transcripts_ui_transcript_options($vars)
 {
 
-    $out  = "<select multiple class='selectpicker tier-selector' data-header='Select languages'>";
+    $out  = "<select multiple class='selectpicker tier-selector' data-header='Select languages' aria-label='Transcript language and speaker selector'>";
 
     //language selector
     $out .= "<optgroup label='Transcript' data-type='languages'>";


### PR DESCRIPTION
# What does this Pull Request do?
Adds an `area-label` attribute to the language and speaker selector. This is the only error identified by the Web AIM accessibility checker for the transcript user interface.

# How should this be tested?
Use the [WAVE chrome extension](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh?hl=en-US) to view an oral history object with a transcription present. Prior to applying this change, a "missing form label" error is flagged on the select element identified by `data-header="Select languages"`

After applying this code change and re-running the accessibility test on this page, the accessibility error disappears.

# Additional Notes:

Does the aria-label "Transcript language and speaker selector" make sense?

* Does this change require documentation to be updated?
  No
* Does this change add any new dependencies?
  No
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)?
  No
* Could this change impact execution of existing code?
  No

# Interested parties
@Natkeeran @MarcusBarnes 